### PR TITLE
Fix console commands breaking in deploys

### DIFF
--- a/SentryPlugin.php
+++ b/SentryPlugin.php
@@ -126,7 +126,7 @@ class SentryPlugin extends BasePlugin
         require_once CRAFT_PLUGINS_PATH.'sentry/vendor/autoload.php';
 
         // Initialize Sentry
-        $client = new Raven_Client(craft()->sentry->dsn);
+        $client = new Raven_Client(craft()->sentry->dsn());
         $client->tags_context(array('environment' => CRAFT_ENVIRONMENT));
 
         $this->attachRavenErrorHandlers($client);
@@ -198,7 +198,7 @@ class SentryPlugin extends BasePlugin
 
         craft()->templates->includeJsFile('https://cdn.ravenjs.com/1.1.22/jquery,native/raven.min.js');
 
-        $publicDsn = craft()->sentry->publicDsn;
+        $publicDsn = craft()->sentry->publicDsn();
         if (empty($publicDsn)) {
             return $this;
         }

--- a/services/SentryService.php
+++ b/services/SentryService.php
@@ -1,0 +1,75 @@
+<?php
+namespace Craft;
+
+class SentryService extends BaseApplicationComponent
+{
+    /**
+     * The Sentry plugin instance.
+     *
+     * @var \Craft\SentryPlugin
+     */
+    protected $plugin;
+
+    /**
+     * Sentry's settings.
+     *
+     * @var array
+     */
+    protected $settings;
+
+    /**
+     * Get Sentry's settings.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->plugin = craft()->plugins->getPlugin('sentry');
+        $this->settings = $this->plugin->getSettings();
+    }
+
+    /**
+     * Returns Sentry DSN.
+     *
+     * @return string
+     */
+    public function dsn()
+    {
+        if ($dsn = craft()->config->get('sentryDsn', 'sentry')) {
+            return $dsn;
+        }
+        return $this->settings->getAttribute('dsn');
+    }
+
+    /**
+     * True if the Sentry DSN is specified by the environment (.env or whatever)
+     * @return boolean
+     */
+    public function isDsnSpecifiedByEnv()
+    {
+        return craft()->config->get('sentryDsn', 'sentry') ? true : false;
+    }
+
+    /**
+     * Returns Sentry public DSN.
+     *
+     * @return string
+     */
+    public function publicDsn()
+    {
+        if ($publicDsn = craft()->config->get('sentryPublicDsn', 'sentry')) {
+            return $publicDsn;
+        }
+        return $this->settings->getAttribute('publicDsn');
+    }
+    
+    /**
+     * True if the Sentry public DSN is specified by the environment (.env or whatever)
+     * @return boolean
+     */
+    public function isPublicDsnSpecifiedByEnv()
+    {
+        return craft()->config->get('sentryPublicDsn', 'sentry') ? true : false;
+    }
+
+}

--- a/variables/SentryVariable.php
+++ b/variables/SentryVariable.php
@@ -40,10 +40,7 @@ class SentryVariable
      */
     public function dsn()
     {
-        if ($dsn = craft()->config->get('sentryDsn', 'sentry')) {
-            return $dsn;
-        }
-        return $this->_settings->getAttribute('dsn');
+        return craft()->sentry->dns();
     }
 
     /**
@@ -52,7 +49,7 @@ class SentryVariable
      */
     public function isDsnSpecifiedByEnv()
     {
-        return craft()->config->get('sentryDsn', 'sentry') ? true : false;
+        return craft()->sentry->isDsnSpecifiedByEnv();
     }
 
     /**
@@ -62,10 +59,7 @@ class SentryVariable
      */
     public function publicDsn()
     {
-        if ($publicDsn = craft()->config->get('sentryPublicDsn', 'sentry')) {
-            return $publicDsn;
-        }
-        return $this->_settings->getAttribute('publicDsn');
+        return craft()->sentry->publicDsn();
     }
     
     /**
@@ -74,7 +68,7 @@ class SentryVariable
      */
     public function isPublicDsnSpecifiedByEnv()
     {
-        return craft()->config->get('sentryPublicDsn', 'sentry') ? true : false;
+        return craft()->sentry->isPublicDsnSpecifiedByEnv();
     }
 
     /**


### PR DESCRIPTION
Console commands break due to the new reliance of the plugins file on the variable file that doesn't seem to get loaded in some console app instances. This commit fixes that by moving the config code to the SentryService.php.

In the future I'll probably want to move a lot more code from SentryPlugin.php to SentryService.php.
